### PR TITLE
XIVY-15609 Improve path encoding for signing request

### DIFF
--- a/src/main/java/com/axonivy/connector/aws/authentication/CanonicalRequest.java
+++ b/src/main/java/com/axonivy/connector/aws/authentication/CanonicalRequest.java
@@ -3,8 +3,9 @@ package com.axonivy.connector.aws.authentication;
 import static com.axonivy.connector.aws.authentication.Constants.SIGNED_HEADERS;
 import static com.axonivy.connector.aws.authentication.Constants.X_AMZ_DATE;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.client.ClientRequestContext;
 
@@ -41,13 +42,16 @@ class CanonicalRequest {
     if (path == null || path.isEmpty()) {
       path = "/";
     }
-
     try {
-      var encodedPath = new URI(null, null, path, null).toASCIIString();
+      var encodedPath = URLEncoder.encode(path, StandardCharsets.UTF_8.toString())
+              .replace("%2F", "/")
+              .replace("%7E", "~")
+              .replace("*", "%2A")
+              .replace("+", "%20");
       builder.append(encodedPath);
       builder.append('\n');
-    } catch (URISyntaxException ex) {
-      throw new RuntimeException(ex);
+    } catch (UnsupportedEncodingException ex) {
+      throw new RuntimeException("Unable to encode path " + path, ex);
     }
   }
 


### PR DESCRIPTION
Using UrlEncoder which is not especially designed for this.
It's hard to find out, how the calling end url is, because
this relies on the underlying technology jersey -> connectory
-> apache http connector. Tried a lot of stuff and this implementation
was the best. It specially handles the characters which are also
specially handled in UrlEncoder.

The main problem is that we should not allow to create such documents.
We should difference between a display name and a technical file name.

@weissreto I'm not happy with the solution, but invested already multiple hours. This solution is at least working for a lot of special characters. 
